### PR TITLE
Fix 'Default' directory path because it's pointing to old location.

### DIFF
--- a/Bind/include/Core/Utils/PathUtils.h
+++ b/Bind/include/Core/Utils/PathUtils.h
@@ -10,7 +10,6 @@
 class PathUtils {
 public:
     static QString getProjectRoot();
-    static QString getBuildToolsPath();
     static QString getBackupsPath();
     static QString getDefaultPath();
     static QString getSysCallerPath();

--- a/Bind/src/Core/Utils/PathUtils.cpp
+++ b/Bind/src/Core/Utils/PathUtils.cpp
@@ -22,10 +22,6 @@ QString PathUtils::getProjectRoot() {
     return s_projectRoot;
 }
 
-QString PathUtils::getBuildToolsPath() {
-    return getProjectRoot() + "/BuildTools";
-}
-
 QString PathUtils::getBackupsPath() {
     return getProjectRoot() + "/Backups";
 }
@@ -35,7 +31,7 @@ QString PathUtils::getHashBackupsPath() {
 }
 
 QString PathUtils::getDefaultPath() {
-    return getBuildToolsPath() + "/Default";
+    return getProjectRoot() + "/Default";
 }
 
 QString PathUtils::getSysCallerPath() {
@@ -138,7 +134,6 @@ bool PathUtils::isProjectRoot(const QString& path) {
     QStringList requiredItems = {
         "SysCaller",
         "SysCallerK",
-        "BuildTools",
         "Backups",
         "Bindings"
     };
@@ -151,7 +146,7 @@ bool PathUtils::isProjectRoot(const QString& path) {
             qDebug() << "Missing Project Root Item:" << item;
         }
     }
-    bool isValid = (foundItems >= 4);
+    bool isValid = (foundItems >= 3);
     qDebug() << "Project Root Validation Result:" << isValid << "(" << foundItems << "/" << requiredItems.size() << " Items Found)";
     return isValid;
 }
@@ -160,7 +155,6 @@ void PathUtils::debugPathDetection() {
     qDebug() << "=== PathUtils Debug Information ===";
     qDebug() << "Application Directory:" << QApplication::applicationDirPath();
     qDebug() << "Project Root:" << getProjectRoot();
-    qDebug() << "BuildTools Path:" << getBuildToolsPath();
     qDebug() << "Backups Path:" << getBackupsPath();
     qDebug() << "Hash Backups Path:" << getHashBackupsPath();
     qDebug() << "Default Path:" << getDefaultPath();

--- a/Bind/src/GUI/Settings/Tabs/GeneralTab.cpp
+++ b/Bind/src/GUI/Settings/Tabs/GeneralTab.cpp
@@ -214,7 +214,7 @@ void GeneralTab::restoreDefaultFiles() {
         QString headerPath = PathUtils::getSysFunctionsPath(isKernelMode);
         if (!QFile::exists(defaultAsmPath) || !QFile::exists(defaultHeaderPath)) {
             QMessageBox::warning(this, "Bind - v1.2.0", 
-                               "Default files not found in BuildTools/Default directory.");
+                               "Default files not found in Default directory.");
             return;
         }
         if (createBackup->isChecked()) {


### PR DESCRIPTION
- Added fix for default path pointing to old PyQt BuildTools location.